### PR TITLE
Fix tier editing bug

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -153,7 +153,9 @@ function bumpRank(delta) {
 // ----------------------
 function openTierModal(tier) {
   currentTierViewing = tier;
-  tierImages = ratingMap[tier];
+  // Make a copy so modifications inside the modal don't directly mutate
+  // the original ratingMap array until we explicitly update it.
+  tierImages = ratingMap[tier].slice();
   currentTierImageIndex = 0;
 
   document.getElementById("tier-modal-number").textContent = tier;


### PR DESCRIPTION
## Summary
- avoid mutating rating arrays in modal by copying arrays in `openTierModal`

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_b_683ca2a5298483309fca0a41d9d50099