### PR TITLE
Add dataset-isolated ranking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ This application provides a **web-based interface** for uploading, viewing, and 
    - **public/**: Contains `index.html`, `style.css`, `script.js`, and possibly other client-side assets.  
    - **images/**: Where uploaded images are stored. The server automatically creates this folder if it doesn’t exist.  
 
-4. **Start the Server**  
+4. **Start the Server**
    ```bash
-   node server.js
+   # optional: specify a dataset name to keep rankings separate
+   DATASET=my-dataset node server.js
    ```
-   By default, it runs on **http://localhost:3000** (adjustable in the code).
+   By default, it runs on **http://localhost:3000** (adjustable in the code) and stores
+   uploaded images under `images/my-dataset` (or `images/default` if omitted).
 
 ## Usage
 
@@ -67,7 +69,8 @@ This application provides a **web-based interface** for uploading, viewing, and 
 
 ## Configuration
 
-- **Port**: Currently defaults to `PORT = 3000` in `server.js`. You can change it by editing the code or using environment variables.  
+- **Port**: Currently defaults to `PORT = 3000` in `server.js`. You can change it by editing the code or using environment variables.
+- **Dataset**: Set `DATASET=my-dataset` when starting the server to store images and ranking data in `images/my-dataset`. The browser keeps separate local storage per dataset automatically.
 - **File Size Limit**: Multer is configured to accept up to 50MB per file. Adjust in `server.js` if needed.
 
 ## Potential Issues & Troubleshooting

--- a/public/script.js
+++ b/public/script.js
@@ -11,11 +11,26 @@ let currentTierViewing = 0;       // which tier is being viewed in the modal
 let tierImages = [];             // array of images in that tier
 let currentTierImageIndex = 0;   // index of the currently displayed image in tierImages
 
+// Dataset identifier provided by the server so local storage can remain
+// separated for different image sets.
+let datasetId = 'default';
+let LS_PREFIX = `dataset_${datasetId}_`;
+
 // -----------------------------
 // On Page Load
 // -----------------------------
 document.addEventListener("DOMContentLoaded", async () => {
-  loadStateFromLocalStorage(); 
+  try {
+    const dsResp = await fetch("/api/dataset");
+    if (dsResp.ok) {
+      const data = await dsResp.json();
+      datasetId = data.dataset || "default";
+    }
+  } catch (err) {
+    console.error("Error fetching dataset information:", err);
+  }
+  LS_PREFIX = `dataset_${datasetId}_`;
+  loadStateFromLocalStorage();
 
   try {
     const resp = await fetch('/api/list-images');
@@ -378,29 +393,29 @@ function exportRankings() {
 // Local Storage
 // ----------------------
 function loadStateFromLocalStorage() {
-  const savedImages = localStorage.getItem('images');
+  const savedImages = localStorage.getItem(`${LS_PREFIX}images`);
   if (savedImages) {
     images = JSON.parse(savedImages);
   }
-  const savedIndex = localStorage.getItem('currentImageIndex');
+  const savedIndex = localStorage.getItem(`${LS_PREFIX}currentImageIndex`);
   if (savedIndex) {
     currentImageIndex = parseInt(savedIndex, 10);
   }
-  const savedRatingMap = localStorage.getItem('ratingMap');
+  const savedRatingMap = localStorage.getItem(`${LS_PREFIX}ratingMap`);
   if (savedRatingMap) {
     ratingMap = JSON.parse(savedRatingMap);
   }
-  const savedHistory = localStorage.getItem('history');
+  const savedHistory = localStorage.getItem(`${LS_PREFIX}history`);
   if (savedHistory) {
     history = JSON.parse(savedHistory);
   }
 }
 
 function saveStateToLocalStorage() {
-  localStorage.setItem('images', JSON.stringify(images));
-  localStorage.setItem('currentImageIndex', currentImageIndex);
-  localStorage.setItem('ratingMap', JSON.stringify(ratingMap));
-  localStorage.setItem('history', JSON.stringify(history));
+  localStorage.setItem(`${LS_PREFIX}images`, JSON.stringify(images));
+  localStorage.setItem(`${LS_PREFIX}currentImageIndex`, currentImageIndex);
+  localStorage.setItem(`${LS_PREFIX}ratingMap`, JSON.stringify(ratingMap));
+  localStorage.setItem(`${LS_PREFIX}history`, JSON.stringify(history));
 }
 
 // ----------------------
@@ -455,10 +470,10 @@ async function resetTierBoard(shouldDelete) {
   history = [];
   ratingMap = { 1: [], 2: [], 3: [], 4: [], 5: [] };
 
-  localStorage.removeItem('images');
-  localStorage.removeItem('currentImageIndex');
-  localStorage.removeItem('ratingMap');
-  localStorage.removeItem('history');
+  localStorage.removeItem(`${LS_PREFIX}images`);
+  localStorage.removeItem(`${LS_PREFIX}currentImageIndex`);
+  localStorage.removeItem(`${LS_PREFIX}ratingMap`);
+  localStorage.removeItem(`${LS_PREFIX}history`);
 
   if (shouldDelete) {
     try {

--- a/server.js
+++ b/server.js
@@ -6,13 +6,21 @@ const fs = require('fs');
 const app = express();
 const PORT = 3000;
 
+// Dataset name can be provided via env var. Images will be stored in
+// `images/<DATASET>` so multiple datasets remain isolated.
+const DATASET = process.env.DATASET || 'default';
+
 // Serve the `public` directory statically
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Configure the images directory
-const IMAGES_DIR = path.join(__dirname, 'images');
+// Configure the images directory for the selected dataset
+const BASE_IMAGES_DIR = path.join(__dirname, 'images');
+const IMAGES_DIR = path.join(BASE_IMAGES_DIR, DATASET);
 
-// Ensure the images folder exists
+// Ensure the dataset folder exists
+if (!fs.existsSync(BASE_IMAGES_DIR)) {
+    fs.mkdirSync(BASE_IMAGES_DIR);
+}
 if (!fs.existsSync(IMAGES_DIR)) {
     fs.mkdirSync(IMAGES_DIR);
 }
@@ -92,6 +100,14 @@ app.get('/api/list-images', (req, res) => {
         // Map filenames to their accessible URLs
         res.json(images.map(file => `/images/${file}`));
     });
+});
+
+/**
+ * GET /api/dataset
+ * Returns the current dataset name so the client can isolate its local storage
+ */
+app.get('/api/dataset', (req, res) => {
+    res.json({ dataset: DATASET });
 });
 
 /**


### PR DESCRIPTION
## Summary
- support dataset subfolders on the server via `DATASET` env var
- expose `/api/dataset` so the client can know which dataset is active
- separate local storage keys per dataset in `script.js`
- document dataset usage and configuration in README

## Testing
- `npm test` *(fails: Missing script)*
- `DATASET=test node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_683cabfa65fc8330bed34b540d4b4fac